### PR TITLE
Don't fail when there's no data

### DIFF
--- a/views/TopEntities/cloud.jsx
+++ b/views/TopEntities/cloud.jsx
@@ -7,24 +7,29 @@ let ratio;
 let computeSize;
 
 const Cloud = props => {
-  largest = props.data.reduce((prev, cur) => (cur.matching_results > prev ? cur.matching_results : prev), 0);
+  largest = props.data ?
+    props.data.reduce((prev, cur) => (cur.matching_results > prev ? cur.matching_results : prev), 0) :
+    0;
   ratio = MAX_SIZE / largest;
   computeSize = (value) => Math.max(MIN_SIZE, value * ratio);
   return (
     <div className="top-entities--cloud">
-      {props.data.map((item, index) =>
-        <div
-          className="top-entities--word"
-          key={`${index}-${item.key}`}
-          title={item.matching_results}
-          style={{
-            fontSize: `${computeSize(item.matching_results)}px`,
-            fontWeight: (computeSize(item.matching_results) < 13 ? 400 : null),
-          }}
-        >
-          {item.key}
-        </div>
-      )}
+      {
+        props.data ?
+        props.data.map((item, index) =>
+          <div
+            className="top-entities--word"
+            key={`${index}-${item.key}`}
+            title={item.matching_results}
+            style={{
+              fontSize: `${computeSize(item.matching_results)}px`,
+              fontWeight: (computeSize(item.matching_results) < 13 ? 400 : null),
+            }}
+          >
+            {item.key}
+          </div>) :
+        []
+      }
     </div>
   );
 };

--- a/views/TopEntities/index.jsx
+++ b/views/TopEntities/index.jsx
@@ -57,8 +57,13 @@ export default React.createClass({
               </Pane>
               <Pane label="Companies">
                 <Cloud
-                  data={this.props.entities.companies.filter((item) =>
-                    item.key.toLowerCase() !== this.props.query.text.toLowerCase())} />
+                  data={
+                    this.props.entities.companies ?
+                    this.props.entities.companies.filter((item) =>
+                      item.key.toLowerCase() !== this.props.query.text.toLowerCase()) :
+                    []
+                  }
+                />
               </Pane>
             </Tabs>
           </div>


### PR DESCRIPTION
If no data exists for companies/people, the news demo app fails
and just leaves the loading spinner up. This commit changes that
behavior so it loads an empty space instead and you can still see
everything else.