### PR TITLE
Revert "Look for companies/people in the right place"

### DIFF
--- a/views/demo.jsx
+++ b/views/demo.jsx
@@ -46,10 +46,10 @@ const parseQueryResults = (data) => {
     if (aggregation.type === 'nested' && aggregation.path === 'enrichedTitle.entities') {
       const entities = aggregation.aggregations;
       if (entities && entities.length > 0 && hasResults(entities[0])) {
-        if (entities[0].match === 'Company') {
+        if (entities[0].match === 'enrichedTitle.entities.type:Company') {
           parsedData.entities.companies = entities[0].aggregations[0].results;
         }
-        if (entities[0].match === 'Person') {
+        if (entities[0].match === 'enrichedTitle.entities.type:Person') {
           parsedData.entities.people = entities[0].aggregations[0].results;
         }
       }


### PR DESCRIPTION
This reverts commit b6f9ff5157f240200e46ad5f22b593e826f97fdf.

Apparently the FE API reverted back to what it was before.

Without this PR (live now), the Discovery demo doesn't have companies or people showing up. With this revert, they show up appropriately.