### PR TITLE
Update link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,5 +196,5 @@ This data is collected from the `package.json` file in the sample application an
 [cloud_foundry]: https://github.com/cloudfoundry/cli
 [getting_started]: https://www.ibm.com/watson/developercloud/doc/common/index.html
 [service_url]: http://www.ibm.com/watson/developercloud/discovery.html
-[docs]: http://www.ibm.com/watson/developercloud/discovery/
+[docs]: http://www.ibm.com/watson/developercloud/doc/discovery/index.html
 [sign_up]: https://console.ng.bluemix.net/registration/

--- a/views/layout.jsx
+++ b/views/layout.jsx
@@ -35,7 +35,7 @@ function Layout(props) {
         <Jumbotron
           serviceName="Discovery"
           repository="https://github.com/watson-developer-cloud/discovery-nodejs"
-          documentation="http://www.ibm.com/watson/developercloud/doc/discovery"
+          documentation="http://www.ibm.com/watson/developercloud/doc/discovery/index.html"
           apiReference="http://www.ibm.com/watson/developercloud/discovery/api"
           startInBluemix="https://console.ng.bluemix.net/registration/?target=/catalog/services/discovery/"
           version="GA"


### PR DESCRIPTION
- After conversion to Markdown, file name changed.
- Link in readme was going to API reference, not main docs. Updated to point to
latest Markdown-sourced output