### PR TITLE
Fixes bug selecting relevance after date

### DIFF
--- a/views/TopStories/index.jsx
+++ b/views/TopStories/index.jsx
@@ -62,9 +62,10 @@ export default React.createClass({
   },
 
   getInitialState() {
+    console.log(this.props.query.sort);
     return {
       showQuery: false,
-      sortType: (typeof this.props.query.sort === 'undefined' || this.props.query.sort == '') ? 'relevance' : 'date',
+      sortType: (typeof this.props.query.sort === 'undefined' || this.props.query.sort == 'relevance') ? 'relevance' : 'date',
     };
   },
 

--- a/views/TopStories/index.jsx
+++ b/views/TopStories/index.jsx
@@ -62,7 +62,6 @@ export default React.createClass({
   },
 
   getInitialState() {
-    console.log(this.props.query.sort);
     return {
       showQuery: false,
       sortType: (typeof this.props.query.sort === 'undefined' || this.props.query.sort == 'relevance') ? 'relevance' : 'date',


### PR DESCRIPTION
We were checking for irrelevant state in the logic that sets
the sort value to relevance from date. This fixes that.