### PR TITLE
Refactor widget queries to live closer to widgets

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,8 +52,11 @@ function getWidgetQuery(request) {
 
       if (widgetAggregations) {
         const currentAggregations = finalWidgetQuery.aggregations || [];
-        finalWidgetQuery.aggregations = currentAggregations.concat(widgetAggregations);
         delete queryBuilderWidgetQuery.aggregations;
+
+        return Object.assign({}, finalWidgetQuery, queryBuilderWidgetQuery, {
+          aggregations: currentAggregations.concat(widgetAggregations),
+        });
       }
     }
     return Object.assign({}, finalWidgetQuery, queryBuilderWidgetQuery);

--- a/app.js
+++ b/app.js
@@ -28,7 +28,6 @@ const discovery = new DiscoveryV1({
   // username: '<username>',
   // password: '<password>',
   version_date: '2017-08-01',
-  qs: { aggregation: `[${queryBuilder.aggregations.join(',')}]` },
 });
 
 // Bootstrap application settings
@@ -44,7 +43,11 @@ app.get('/', (req, res) => {
 
 // setup query endpoint for news
 app.post('/api/query', (req, res, next) => {
-  const params = Object.assign({}, queryBuilder.build(req.body), {
+  const queryParams = queryBuilder.build(req.body);
+  if (queryParams.aggregations) {
+    delete queryParams.aggregations;
+  }
+  const params = Object.assign({}, queryParams, {
     environment_id: NEWS_ENVIRONMENT_ID,
     collection_id: NEWS_COLLECTION_ID,
   });

--- a/src/AnomalyDetection/index.jsx
+++ b/src/AnomalyDetection/index.jsx
@@ -57,6 +57,21 @@ export default class AnomalyDetection extends Component {
     return anomalyData.some(result => result.anomaly);
   }
 
+  static trimAnomalyResultsForDisplay(anomalyData) {
+    return anomalyData.map((timesliceResult) => {
+      const aggregations = timesliceResult.aggregations.map((topHitAgg) => {
+        const hits = Object.assign({}, topHitAgg.hits, {
+          hits: topHitAgg.hits.hits.map(topHit =>
+            // returning all the fields makes everything slow
+            ({ title: topHit.title }),
+          ),
+        });
+        return Object.assign({}, topHitAgg, { hits });
+      });
+      return Object.assign({}, timesliceResult, { aggregations });
+    });
+  }
+
   state = {
     showQuery: false,
     showOverlay: !AnomalyDetection.hasAnomalies(this.props.anomalyData),
@@ -161,7 +176,7 @@ export default class AnomalyDetection extends Component {
               <QuerySyntax
                 title={AnomalyDetection.widgetTitle()}
                 query={queryBuilder.build(query, widgetQuery)}
-                response={{ results: anomalyData }}
+                response={{ results: AnomalyDetection.trimAnomalyResultsForDisplay(anomalyData) }}
                 onGoBack={this.onShowResults}
               />
             )

--- a/src/AnomalyDetection/index.jsx
+++ b/src/AnomalyDetection/index.jsx
@@ -18,6 +18,7 @@ import NoContent from '../NoContent/index';
 import AnomalyDot from './AnomalyDot';
 import AnomalyTooltip from './AnomalyTooltip';
 import NoAnomaliesOverlay from './NoAnomaliesOverlay';
+import widgetQuery from './query';
 
 export default class AnomalyDetection extends Component {
   static propTypes = {
@@ -159,7 +160,7 @@ export default class AnomalyDetection extends Component {
             : (
               <QuerySyntax
                 title={AnomalyDetection.widgetTitle()}
-                query={queryBuilder.build(query, true)}
+                query={queryBuilder.build(query, widgetQuery)}
                 response={{ results: anomalyData }}
                 onGoBack={this.onShowResults}
               />

--- a/src/AnomalyDetection/index.jsx
+++ b/src/AnomalyDetection/index.jsx
@@ -18,7 +18,6 @@ import NoContent from '../NoContent/index';
 import AnomalyDot from './AnomalyDot';
 import AnomalyTooltip from './AnomalyTooltip';
 import NoAnomaliesOverlay from './NoAnomaliesOverlay';
-import widgetQuery from './query';
 
 export default class AnomalyDetection extends Component {
   static propTypes = {
@@ -175,7 +174,7 @@ export default class AnomalyDetection extends Component {
             : (
               <QuerySyntax
                 title={AnomalyDetection.widgetTitle()}
-                query={queryBuilder.build(query, widgetQuery)}
+                query={queryBuilder.build(query, queryBuilder.widgetQueries.anomalyDetection)}
                 response={{ results: AnomalyDetection.trimAnomalyResultsForDisplay(anomalyData) }}
                 onGoBack={this.onShowResults}
               />

--- a/src/AnomalyDetection/query.js
+++ b/src/AnomalyDetection/query.js
@@ -9,5 +9,5 @@ const timesliceParams = [
 const anomalyAgg = `timeslice(${timesliceParams}).top_hits(1)`;
 
 module.exports = {
-  aggregations: [ anomalyAgg ],
+  aggregations: [anomalyAgg],
 };

--- a/src/AnomalyDetection/query.js
+++ b/src/AnomalyDetection/query.js
@@ -1,0 +1,13 @@
+const { fields } = require('../fields');
+
+const timesliceParams = [
+  `field:${fields.publication_date}`,
+  'interval:1day',
+  'time_zone:America/New_York',
+  'anomaly:true',
+].join(',');
+const anomalyAgg = `timeslice(${timesliceParams}).top_hits(1)`;
+
+module.exports = {
+  aggregations: [ anomalyAgg ],
+};

--- a/src/MentionsAndSentiments/index.jsx
+++ b/src/MentionsAndSentiments/index.jsx
@@ -18,7 +18,6 @@ import Accordion from '../Accordion/index';
 import NoContent from '../NoContent/index';
 import { getNames, getItemsForName } from './mentionsParser';
 import capitalize from './capitalize';
-import widgetQuery from './query';
 
 export default class MentionsAndSentiments extends Component {
   static propTypes = {
@@ -271,7 +270,7 @@ export default class MentionsAndSentiments extends Component {
             : (
               <QuerySyntax
                 title={MentionsAndSentiments.widgetTitle()}
-                query={queryBuilder.build(query, widgetQuery)}
+                query={queryBuilder.build(query, queryBuilder.widgetQueries.mentionsAndSentiments)}
                 response={{ mentions }}
                 onGoBack={this.onShowResults}
               />

--- a/src/MentionsAndSentiments/index.jsx
+++ b/src/MentionsAndSentiments/index.jsx
@@ -18,6 +18,7 @@ import Accordion from '../Accordion/index';
 import NoContent from '../NoContent/index';
 import { getNames, getItemsForName } from './mentionsParser';
 import capitalize from './capitalize';
+import widgetQuery from './query';
 
 export default class MentionsAndSentiments extends Component {
   static propTypes = {
@@ -270,7 +271,7 @@ export default class MentionsAndSentiments extends Component {
             : (
               <QuerySyntax
                 title={MentionsAndSentiments.widgetTitle()}
-                query={queryBuilder.build(query, true)}
+                query={queryBuilder.build(query, widgetQuery)}
                 response={{ mentions }}
                 onGoBack={this.onShowResults}
               />

--- a/src/MentionsAndSentiments/query.js
+++ b/src/MentionsAndSentiments/query.js
@@ -1,0 +1,12 @@
+const { fields } = require('../fields');
+
+const mentionsAgg = [
+  `filter(${fields.title_entity_type}::Company)`,
+  `term(${fields.title_entity_text})`,
+  `timeslice(${fields.publication_date},1day)`,
+  `term(${fields.text_document_sentiment_type})`,
+].join('.');
+
+module.exports = {
+  aggregations: [ mentionsAgg ],
+};

--- a/src/MentionsAndSentiments/query.js
+++ b/src/MentionsAndSentiments/query.js
@@ -8,5 +8,5 @@ const mentionsAgg = [
 ].join('.');
 
 module.exports = {
-  aggregations: [ mentionsAgg ],
+  aggregations: [mentionsAgg],
 };

--- a/src/QuerySyntax/index.jsx
+++ b/src/QuerySyntax/index.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { string, number, func, object, shape, arrayOf } from 'prop-types';
 import { Tabs, Pane, Code } from 'watson-react-components';
 
-const queryWithoutAggregation = queryInput => {
+const queryWithoutAggregation = (queryInput) => {
   const { aggregation, ...queryParams } = queryInput;
   return queryParams;
-}
+};
 
 function QuerySyntax({ query, response, title, onGoBack }) {
   const queryParams = queryWithoutAggregation(query);

--- a/src/QuerySyntax/index.jsx
+++ b/src/QuerySyntax/index.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { string, number, func, object, shape, arrayOf } from 'prop-types';
 import { Tabs, Pane, Code } from 'watson-react-components';
 
-const stringifyObject = input =>
-  (
-    typeof input === 'object'
-      ? JSON.stringify(input, null, 2)
-      : input
-  );
+const queryWithoutAggregation = queryInput => {
+  const { aggregation, ...queryParams } = queryInput;
+  return queryParams;
+}
 
 function QuerySyntax({ query, response, title, onGoBack }) {
+  const queryParams = queryWithoutAggregation(query);
+
   return (
     <div className="code-results">
       <div className="code-results--header-row">
@@ -36,7 +36,7 @@ function QuerySyntax({ query, response, title, onGoBack }) {
             <div className="code-results--fake-border" />
           </div>
           <Code language="json">
-            { stringifyObject(query) }
+            { JSON.stringify(queryParams, null, 2) }
           </Code>
         </Pane>
         <Pane label="Response">
@@ -44,7 +44,7 @@ function QuerySyntax({ query, response, title, onGoBack }) {
             <div className="code-results--fake-border" />
           </div>
           <Code language="json">
-            { stringifyObject(response) }
+            { JSON.stringify(response, null, 2) }
           </Code>
         </Pane>
       </Tabs>
@@ -54,8 +54,8 @@ function QuerySyntax({ query, response, title, onGoBack }) {
 
 QuerySyntax.propTypes = {
   query: shape({
-    count: number.isRequired,
-    return: string.isRequired,
+    count: number,
+    return: string,
     query: string.isRequired,
     aggregations: arrayOf(string),
     filter: string,

--- a/src/SentimentAnalysis/index.jsx
+++ b/src/SentimentAnalysis/index.jsx
@@ -5,6 +5,7 @@ import SentimentChart from './SentimentChart';
 import SentimentBySource from './SentimentBySource';
 import QuerySyntax from '../QuerySyntax/index';
 import queryBuilder from '../query-builder';
+import widgetQuery from './query';
 
 export default class SentimentAnalysis extends Component {
   static propTypes = {
@@ -86,7 +87,7 @@ export default class SentimentAnalysis extends Component {
             : (
               <QuerySyntax
                 title="Sentiment Analysis"
-                query={queryBuilder.build(query, true)}
+                query={queryBuilder.build(query, widgetQuery)}
                 response={{ sentiment, sentiments }}
                 onGoBack={this.onShowResults}
               />

--- a/src/SentimentAnalysis/index.jsx
+++ b/src/SentimentAnalysis/index.jsx
@@ -5,7 +5,6 @@ import SentimentChart from './SentimentChart';
 import SentimentBySource from './SentimentBySource';
 import QuerySyntax from '../QuerySyntax/index';
 import queryBuilder from '../query-builder';
-import widgetQuery from './query';
 
 export default class SentimentAnalysis extends Component {
   static propTypes = {
@@ -87,7 +86,7 @@ export default class SentimentAnalysis extends Component {
             : (
               <QuerySyntax
                 title="Sentiment Analysis"
-                query={queryBuilder.build(query, widgetQuery)}
+                query={queryBuilder.build(query, queryBuilder.widgetQueries.sentimentAnalysis)}
                 response={{ sentiment, sentiments }}
                 onGoBack={this.onShowResults}
               />

--- a/src/SentimentAnalysis/query.js
+++ b/src/SentimentAnalysis/query.js
@@ -1,0 +1,11 @@
+const { fields } = require('../fields');
+
+const sentimentByHostAgg = [
+  `term(${fields.host})`,
+  `term(${fields.text_document_sentiment_type})`,
+].join('.');
+const overallSentimentAgg = `term(${fields.text_document_sentiment_type})`;
+
+module.exports = {
+  aggregations: [ sentimentByHostAgg, overallSentimentAgg ],
+};

--- a/src/SentimentAnalysis/query.js
+++ b/src/SentimentAnalysis/query.js
@@ -7,5 +7,5 @@ const sentimentByHostAgg = [
 const overallSentimentAgg = `term(${fields.text_document_sentiment_type})`;
 
 module.exports = {
-  aggregations: [ sentimentByHostAgg, overallSentimentAgg ],
+  aggregations: [sentimentByHostAgg, overallSentimentAgg],
 };

--- a/src/TopEntities/index.jsx
+++ b/src/TopEntities/index.jsx
@@ -6,6 +6,7 @@ import Cloud from './Cloud';
 import QuerySyntax from '../QuerySyntax/index';
 import queryBuilder from '../query-builder';
 import NoContent from '../NoContent/index';
+import widgetQuery from './query';
 
 export default class TopEntities extends Component {
   static propTypes = {
@@ -127,7 +128,7 @@ export default class TopEntities extends Component {
             : (
               <QuerySyntax
                 title="Top Entities"
-                query={queryBuilder.build(query, true)}
+                query={queryBuilder.build(query, widgetQuery)}
                 response={this.props.entities}
                 onGoBack={this.onShowResults}
               />

--- a/src/TopEntities/index.jsx
+++ b/src/TopEntities/index.jsx
@@ -6,7 +6,6 @@ import Cloud from './Cloud';
 import QuerySyntax from '../QuerySyntax/index';
 import queryBuilder from '../query-builder';
 import NoContent from '../NoContent/index';
-import widgetQuery from './query';
 
 export default class TopEntities extends Component {
   static propTypes = {
@@ -128,7 +127,7 @@ export default class TopEntities extends Component {
             : (
               <QuerySyntax
                 title="Top Entities"
-                query={queryBuilder.build(query, widgetQuery)}
+                query={queryBuilder.build(query, queryBuilder.widgetQueries.topEntities)}
                 response={this.props.entities}
                 onGoBack={this.onShowResults}
               />

--- a/src/TopEntities/query.js
+++ b/src/TopEntities/query.js
@@ -13,5 +13,5 @@ const peopleAgg = [
 const conceptAgg = `term(${fields.title_concept_text})`;
 
 module.exports = {
-  aggregations: [ companiesAgg, peopleAgg, conceptAgg ],
+  aggregations: [companiesAgg, peopleAgg, conceptAgg],
 };

--- a/src/TopEntities/query.js
+++ b/src/TopEntities/query.js
@@ -1,0 +1,17 @@
+const { fields } = require('../fields');
+
+const companiesAgg = [
+  `nested(${fields.title_entity})`,
+  `filter(${fields.title_entity_type}:Company)`,
+  `term(${fields.title_entity_text})`,
+].join('.');
+const peopleAgg = [
+  `nested(${fields.title_entity})`,
+  `filter(${fields.title_entity_type}:Person)`,
+  `term(${fields.title_entity_text})`,
+].join('.');
+const conceptAgg = `term(${fields.title_concept_text})`;
+
+module.exports = {
+  aggregations: [ companiesAgg, peopleAgg, conceptAgg ],
+};

--- a/src/TopStories/index.jsx
+++ b/src/TopStories/index.jsx
@@ -6,7 +6,6 @@ import queryBuilder from '../query-builder';
 import Story from './Story';
 import SortSelect from './SortSelect';
 import { fields } from '../fields';
-import widgetQuery from './query';
 
 export default class TopStories extends Component {
   static propTypes = {
@@ -94,7 +93,7 @@ export default class TopStories extends Component {
             : (
               <QuerySyntax
                 title="Top Stories"
-                query={queryBuilder.build(query, widgetQuery)}
+                query={queryBuilder.build(query, queryBuilder.widgetQueries.topStories)}
                 response={{ results: stories }}
                 onGoBack={this.onShowResults}
               />

--- a/src/TopStories/index.jsx
+++ b/src/TopStories/index.jsx
@@ -6,6 +6,7 @@ import queryBuilder from '../query-builder';
 import Story from './Story';
 import SortSelect from './SortSelect';
 import { fields } from '../fields';
+import widgetQuery from './query';
 
 export default class TopStories extends Component {
   static propTypes = {
@@ -93,7 +94,7 @@ export default class TopStories extends Component {
             : (
               <QuerySyntax
                 title="Top Stories"
-                query={queryBuilder.build(query, true)}
+                query={queryBuilder.build(query, widgetQuery)}
                 response={{ results: stories }}
                 onGoBack={this.onShowResults}
               />

--- a/src/TopStories/query.js
+++ b/src/TopStories/query.js
@@ -1,0 +1,13 @@
+const { fields } = require('../fields');
+
+const returnFields = [
+  fields.title,
+  fields.url,
+  fields.host,
+  fields.publication_date,
+].join(',');
+
+module.exports = {
+  count: 5,
+  return: returnFields,
+};

--- a/src/__test__/AnomalyDetection/index.test.jsx
+++ b/src/__test__/AnomalyDetection/index.test.jsx
@@ -16,6 +16,23 @@ describe('<AnomalyDetection />', () => {
         key_as_string: '2017-08-01T00:00:00.000-04:00',
         matching_results: 10,
         anomaly: 0.5,
+        aggregations: [
+          {
+            type: 'top_hits',
+            size: 1,
+            hits: {
+              matching_results: 123,
+              hits: [
+                {
+                  id: 'im an id',
+                  score: 1.0,
+                  field: 'im some field',
+                  title: 'the real title',
+                },
+              ],
+            },
+          },
+        ],
       },
     ],
     query: {
@@ -107,7 +124,29 @@ describe('<AnomalyDetection />', () => {
 
         expect(querySyntaxProps.query.query).toEqual(expectedQuery);
         expect(querySyntaxProps.title).toEqual(AnomalyDetection.widgetTitle());
-        expect(querySyntaxProps.response).toEqual({ results: props.anomalyData });
+
+        const expectedResults = [
+          {
+            key_as_string: '2017-08-01T00:00:00.000-04:00',
+            matching_results: 10,
+            anomaly: 0.5,
+            aggregations: [
+              {
+                type: 'top_hits',
+                size: 1,
+                hits: {
+                  matching_results: 123,
+                  hits: [
+                    {
+                      title: 'the real title',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ];
+        expect(querySyntaxProps.response).toEqual({ results: expectedResults });
       });
     });
   });

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -36,7 +36,8 @@ module.exports = {
       TopEntitiesQuery.aggregations,
       SentimentAnalysisQuery.aggregations,
       MentionsAndSentimentsQuery.aggregations,
-      AnomalyDetectionQuery.aggregations,
+      // eslint-disable-next-line comma-dangle
+      AnomalyDetectionQuery.aggregations
     );
     params.aggregation = `[${allWidgetAggregations.join(',')}]`;
     // add in TopStoriesQuery since it is the only one without aggregations

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -10,6 +10,13 @@ const AnomalyDetectionQuery = require('./AnomalyDetection/query');
 const ISO_8601 = 'YYYY-MM-DDThh:mm:ssZZ';
 
 module.exports = {
+  widgetQueries: {
+    topStories: TopStoriesQuery,
+    topEntities: TopEntitiesQuery,
+    sentimentAnalysis: SentimentAnalysisQuery,
+    mentionsAndSentiments: MentionsAndSentimentsQuery,
+    anomalyDetection: AnomalyDetectionQuery,
+  },
   build(query, widgetQuery) {
     const params = {
       query: `"${query.text}",${fields.language}:(english|en)`,
@@ -21,13 +28,10 @@ module.exports = {
       params.sort = query.sort === 'date' ? `-${fields.publication_date},-_score` : '-_score';
     }
     if (widgetQuery) {
-      const widgetQueryCopy = Object.assign({}, widgetQuery);
-
-      if (widgetQueryCopy.aggregations) {
-        params.aggregation = `[${widgetQueryCopy.aggregations.join(',')}]`;
-      }
-      return Object.assign({}, params, widgetQueryCopy);
+      return Object.assign({}, params, widgetQuery);
     }
+
+    // do a full query
     const allWidgetAggregations = [].concat(
       TopEntitiesQuery.aggregations,
       SentimentAnalysisQuery.aggregations,

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -27,16 +27,15 @@ module.exports = {
         params.aggregation = `[${widgetQueryCopy.aggregations.join(',')}]`;
       }
       return Object.assign({}, params, widgetQueryCopy);
-    } else {
-      const allWidgetAggregations = [].concat(
-        TopEntitiesQuery.aggregations,
-        SentimentAnalysisQuery.aggregations,
-        MentionsAndSentimentsQuery.aggregations,
-        AnomalyDetectionQuery.aggregations,
-      );
-      params.aggregation = `[${allWidgetAggregations.join(',')}]`;
-      // add in TopStoriesQuery since it is the only one without aggregations
-      return Object.assign({}, params, TopStoriesQuery);
     }
+    const allWidgetAggregations = [].concat(
+      TopEntitiesQuery.aggregations,
+      SentimentAnalysisQuery.aggregations,
+      MentionsAndSentimentsQuery.aggregations,
+      AnomalyDetectionQuery.aggregations,
+    );
+    params.aggregation = `[${allWidgetAggregations.join(',')}]`;
+    // add in TopStoriesQuery since it is the only one without aggregations
+    return Object.assign({}, params, TopStoriesQuery);
   },
 };

--- a/src/query-builder.js
+++ b/src/query-builder.js
@@ -1,51 +1,42 @@
-
-const { fields } = require('./fields');
-// Aggregations used to build the different parts of the UI
 const moment = require('moment');
+const { fields } = require('./fields');
+const TopStoriesQuery = require('./TopStories/query');
+const TopEntitiesQuery = require('./TopEntities/query');
+const SentimentAnalysisQuery = require('./SentimentAnalysis/query');
+const MentionsAndSentimentsQuery = require('./MentionsAndSentiments/query');
+const AnomalyDetectionQuery = require('./AnomalyDetection/query');
+
 // ISO 8601 date format accepted by the service
 const ISO_8601 = 'YYYY-MM-DDThh:mm:ssZZ';
 
-const entities = [
-  `nested(${fields.title_entity}).filter(${fields.title_entity_type}:Company).term(${fields.title_entity_text})`,
-  `nested(${fields.title_entity}).filter(${fields.title_entity_type}:Person).term(${fields.title_entity_text})`,
-  `term(${fields.title_concept_text})`,
-];
-
-const sentiments = [
-  `term(${fields.host}).term(${fields.text_document_sentiment_type})`,
-  `term(${fields.text_document_sentiment_type})`,
-  `min(${fields.text_document_sentiment_score})`,
-  `max(${fields.text_document_sentiment_score})`,
-];
-
-const mentions = [
-  `filter(${fields.title_entity_type}::Company).term(${fields.title_entity_text}).timeslice(${fields.publication_date},1day).term(${fields.text_document_sentiment_type})`,
-];
-
-const anomalies = [
-  `timeslice(field:${fields.publication_date},interval:1day,time_zone:America/New_York,anomaly:true).top_hits(1)`,
-];
-
 module.exports = {
-  aggregations: [].concat(entities, sentiments, mentions, anomalies),
-  entities,
-  sentiments,
-  mentions,
-  build(query, full) {
+  build(query, widgetQuery) {
     const params = {
-      count: 5,
-      return: `${fields.title},${fields.url},${fields.host},${fields.publication_date}`,
       query: `"${query.text}",${fields.language}:(english|en)`,
     };
-    if (full) {
-      params.aggregations = [].concat(entities, sentiments, mentions, anomalies);
-    }
     if (query.date) {
       params.filter = `${fields.publication_date}>${moment(query.date.from).format(ISO_8601)},${fields.publication_date}<${moment(query.date.to).format(ISO_8601)}`;
     }
     if (query.sort) {
       params.sort = query.sort === 'date' ? `-${fields.publication_date},-_score` : '-_score';
     }
-    return params;
+    if (widgetQuery) {
+      const widgetQueryCopy = Object.assign({}, widgetQuery);
+
+      if (widgetQueryCopy.aggregations) {
+        params.aggregation = `[${widgetQueryCopy.aggregations.join(',')}]`;
+      }
+      return Object.assign({}, params, widgetQueryCopy);
+    } else {
+      const allWidgetAggregations = [].concat(
+        TopEntitiesQuery.aggregations,
+        SentimentAnalysisQuery.aggregations,
+        MentionsAndSentimentsQuery.aggregations,
+        AnomalyDetectionQuery.aggregations,
+      );
+      params.aggregation = `[${allWidgetAggregations.join(',')}]`;
+      // add in TopStoriesQuery since it is the only one without aggregations
+      return Object.assign({}, params, TopStoriesQuery);
+    }
   },
 };


### PR DESCRIPTION
The widget queries were awfully far away from their actual use, so I moved them closer to each widget.

However, these files do not seem to be auto-reloaded when updated since they are loaded via node instead of webpack during development.